### PR TITLE
Expose a bug resulting from block expectations not being re-evaluated

### DIFF
--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -27,7 +27,7 @@ describe "wait_for" do
 
     it "accepts a block" do
       expect {
-        wait_for { progress }.to eq(".")
+        wait_for { progress.dup }.to eq(".")
       }.not_to raise_error
     end
 
@@ -65,7 +65,7 @@ describe "wait_for" do
 
     it "accepts a block" do
       expect {
-        wait_for { progress }.not_to eq("")
+        wait_for { progress.dup }.not_to eq("")
       }.not_to raise_error
     end
 


### PR DESCRIPTION
:warning: Failing test! For discussion.

In RSpec, some matchers (`eq`) accept a static value to test. Some (`change`) accept a proc that first needs to be evaluated, sometimes multiple times, before testing.

RSpec::Wait requires the ability to re-evaluate a static "actual" value for static matchers.

The first pass at RSpec::Wait allows this by allowing a user to provide a block. My understanding at the time was that in RSpec, both of the following assertions would pass identically:

``` ruby
expect("foo").to eq("foo")
expect { "foo" }.to eq("foo")
```

but in fact, that's not the case. The second assertion above fails, testing equality between a proc and a string.

:b: :o2: :o2: :bangbang:

So RSpec::Wait's syntax is inconsistent with RSpec's own syntax.

Furthermore, how could RSpec::Wait provide a block to a dynamic matcher? How will RSpec::Wait know whether to evaluate the block before passing to the matcher (as it would for a static matcher) or whether to pass the block itself to the matcher (as it would for a dynamic matcher)?
