### PR TITLE
Allows user to change the wait timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ end
 RSpec::Wait ties into RSpec's internals so it can take full advantage of any
 non-block matcher that you would use with RSpec's own `expect` method.
 
+### Configure wait timeout
+
+The timeout before failing can be changed to fit your needs by adding a custom settings in ~/.rspec, .rspec, .rspec-local.
+
+```ruby
+#.rspec
+RSpec.configure do |c|
+	c.add_setting :wait_timeout
+	c.wait_timeout=30 # default is 10 sec
+end
+```
+
 ## Who wrote RSpec::Wait?
 
 My name is Steve Richert and I wrote RSpec::Wait in April, 2014 with the support

--- a/lib/rspec/wait/handler.rb
+++ b/lib/rspec/wait/handler.rb
@@ -6,8 +6,13 @@ require "rspec/wait/error"
 module RSpec
   module Wait
     module Handler
-      TIMEOUT = 10
+   	  if defined?(RSpec.configuration.wait_timeout) then
+		TIMEOUT=RSpec.configuration.wait_timeout
+	  else
+		TIMEOUT=10
+	  end
       DELAY = 0.1
+	  
 
       def handle_matcher(target, *args, &block)
         failure = nil

--- a/spec/timeout_helper.rb
+++ b/spec/timeout_helper.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |c|
+	c.add_setting :wait_timeout
+	c.wait_timeout=1
+end

--- a/spec/wait_timeout_spec.rb
+++ b/spec/wait_timeout_spec.rb
@@ -1,0 +1,25 @@
+require "timeout_helper"
+require "spec_helper"
+	
+
+
+describe "timeout" do
+  let!(:progress) { "" }
+
+  before do
+    Thread.new do
+      2.times do
+        sleep 1
+        progress << "."
+      end
+    end
+
+  end
+  
+  it "can be changed using RSpec.configure" do
+    expect {
+      wait_for { sleep 3; progress }.not_to eq("..")
+    }.to raise_error(RSpec::Wait::TimeoutError)
+  end
+
+end


### PR DESCRIPTION
Hi,
I've been using your gem to validate some of our legacy code. 
In my case, some of the functions took way more than 10sec.

The aim of the modification is basicaly to enable the user to change the timeout in a standard way, using RSpec configuration custom parameters.

I changed the handler.rb to check for custom parameter "wait_timeout" and update specs and documentation accordingly.

(I had to create a separate spec file, because I couldn't find the way to do it otherwise)

Cheers,
Sebastien
