### PR TITLE
Fix bug: The to_not alias is not working correctly when expectation is not met

### DIFF
--- a/lib/rspec/wait/target.rb
+++ b/lib/rspec/wait/target.rb
@@ -36,6 +36,8 @@ module RSpec
         with_wait { NegativeHandler.handle_matcher(@target, matcher, message, &block) }
       end
 
+      alias_method :to_not, :not_to
+
       private
 
       def with_wait

--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -135,10 +135,16 @@ describe "wait_for" do
       }.to raise_error(RuntimeError)
     end
 
-    it "respects the to_not alias" do
+    it "respects the to_not alias when expectation is met" do
       expect {
-        wait_for { progress }.to_not eq("..")
+        wait_for { true }.to_not eq(false)
       }.not_to raise_error
+    end
+
+    it "respects the to_not alias when expectation is not met" do
+      expect {
+        wait_for { true }.to_not eq(true)
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
 
     it "prevents operator matchers" do

--- a/spec/wait_spec.rb
+++ b/spec/wait_spec.rb
@@ -148,10 +148,16 @@ describe "wait" do
         }.to raise_error(RuntimeError)
       end
 
-      it "respects the to_not alias" do
+      it "respects the to_not alias when expectation is met" do
         expect {
-          wait.for { progress }.to_not eq("..")
+          wait(1).for { true }.to_not eq(false)
         }.not_to raise_error
+      end
+
+      it "respects the to_not alias when expectation is not met" do
+        expect {
+          wait(1).for { true }.to_not eq(true)
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
       it "prevents operator matchers" do


### PR DESCRIPTION
In RSpec, the ```to_not``` and ```not_to``` expectations are interchangeable. It turns out that this is not the case for RSpec::Wait, if you have a test where the expectation is not met.
This PR fixes that, so that RSpec::Wait behaves exactly the same as RSpec in this regard.

The previous tests for ```respect the to_not alias``` were based on the ```progress``` variable which would change during the test so that the expectation would always be met at some point in time - so in this PR that has been changed to more simple tests that verify both the positive and the negative case.

The PR adds tests for both positive and negative cases for ```wait``` and ```wait_for```, and a fix to make all tests pass.

...oh, and here's the required GIF:
![cheering_minions](https://cloud.githubusercontent.com/assets/7766557/8105810/c1333f8e-103c-11e5-9c7e-a7df2e9a753f.gif)
