### PR TITLE
Lessen RSpec restrictions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ gemfile:
   - gemfiles/rspec_3_1.gemfile
   - gemfiles/rspec_3_2.gemfile
   - gemfiles/rspec_3_3.gemfile
+  - gemfiles/rspec_3_4.gemfile
 language: ruby
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.8 / 2015-11-13
+
+* [ENHANCEMENT] Add support for RSpec 3.3
+
 ## 0.0.7 / 2015-06-16
 
 * [ENHANCEMENT] Add support for RSpec 3.3

--- a/gemfiles/rspec_3_4.gemfile
+++ b/gemfiles/rspec_3_4.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rspec", "~> 3.4.0"
+
+group :test do
+  gem "codeclimate-test-reporter", require: false
+end

--- a/rspec-wait.gemspec
+++ b/rspec-wait.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files      = `git ls-files -z`.split("\x0")
   spec.test_files = spec.files.grep(/^spec/)
 
-  spec.add_dependency "rspec", ">= 2.11", "< 3.4"
+  spec.add_dependency "rspec", ">= 2.11", "< 3.5"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.4"


### PR DESCRIPTION
Not sure what the exact reason is for the very restrictive RSpec version but I need it for RSpec 3.4.