### PR TITLE
disabled ruby 1.9.3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 rvm:
-  - 1.9.3
+  # - 1.9.3
   - "2.0"
   - "2.1"
   - "2.2"


### PR DESCRIPTION
1.9.3 tests disabled as travis currently fails while trying to solve dependency for json (see below).
I guess the best solution is to drop support for ruby 1.9.3?

```$ rvm use 1.9.3 --install --binary --fuzzy
Using /home/travis/.rvm/gems/ruby-1.9.3-p551
$ export BUNDLE_GEMFILE=$PWD/gemfiles/rspec_2_11.gemfile
cache.1
Setting up build cache
$ export CASHER_DIR=$HOME/.casher
0.12s$ Installing caching utilities
0.00s
0.45sattempting to download cache archive
fetching PR.14/cache-linux-precise-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--rvm-1.9.3--gemfile-gemfilesrspec_2_11.gemfile.tgz
fetching PR.14/cache--rvm-1.9.3--gemfile-gemfilesrspec_2_11.gemfile.tgz
fetching master/cache-linux-precise-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--rvm-1.9.3--gemfile-gemfilesrspec_2_11.gemfile.tgz
fetching master/cache--rvm-1.9.3--gemfile-gemfilesrspec_2_11.gemfile.tgz
could not download cache
cache.bundler
0.00s
0.26sadding /home/travis/build/laserlemon/rspec-wait/gemfiles/vendor/bundle to cache
$ ruby --version
ruby 1.9.3p551 (2014-11-13 revision 48407) [x86_64-linux]
$ rvm --version
rvm 1.26.10 (latest-minor) by Wayne E. Seguin <wayneeseguin@gmail.com>, Michal Papis <mpapis@gmail.com> [https://rvm.io/]
$ bundle --version
Bundler version 1.7.6
$ gem --version
2.4.5
before_install
5.61s$ gem update bundler rake
Updating installed gems
Updating bundler
Fetching: bundler-1.12.5.gem (100%)
Successfully installed bundler-1.12.5
Updating rake
Fetching: rake-11.2.2.gem (100%)
Successfully installed rake-11.2.2
Gems updated: bundler rake
10.79s$ bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Resolving dependencies...
Using bundler 1.12.5
Installing rake 10.5.0
Installing docile 1.1.5
Installing json 2.0.1 with native extensions
Gem::InstallError: json requires Ruby version ~> 2.0.```