### PR TITLE
fix for ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 rvm:
-  - 1.9.3
+  # - 1.9.3
   - "2.0"
   - "2.1"
   - "2.2"
+  - 2.3.0
   - ruby-head
 sudo: false

--- a/lib/rspec/wait.rb
+++ b/lib/rspec/wait.rb
@@ -19,8 +19,8 @@ module RSpec
     end
 
     def with_wait(options)
-      original_timeout = RSpec.configuration.wait_timeout
-      original_delay = RSpec.configuration.wait_delay
+      original_timeout = RSpec.configuration.send(:wait_timeout)
+      original_delay = RSpec.configuration.send(:wait_delay)
 
       RSpec.configuration.wait_timeout = options[:timeout] if options[:timeout]
       RSpec.configuration.wait_delay = options[:delay] if options[:delay]

--- a/lib/rspec/wait/handler.rb
+++ b/lib/rspec/wait/handler.rb
@@ -6,14 +6,14 @@ module RSpec
       def handle_matcher(target, *args, &block)
         failure = nil
 
-        Timeout.timeout(RSpec.configuration.wait_timeout) do
+        Timeout.timeout(RSpec.configuration.send(:wait_timeout)) do
           loop do
             begin
               actual = target.respond_to?(:call) ? target.call : target
               super(actual, *args, &block)
               break
             rescue RSpec::Expectations::ExpectationNotMetError => failure
-              sleep RSpec.configuration.wait_delay
+              sleep RSpec.configuration.send(:wait_delay)
               retry
             end
           end

--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -42,7 +42,7 @@ describe "wait_for" do
     end
 
     it "respects a timeout specified in configuration" do
-      original_timeout = RSpec.configuration.wait_timeout
+      original_timeout = RSpec.configuration.send(:wait_timeout)
       RSpec.configuration.wait_timeout = 3
 
       begin
@@ -111,7 +111,7 @@ describe "wait_for" do
     end
 
     it "respects a timeout specified in configuration" do
-      original_timeout = RSpec.configuration.wait_timeout
+      original_timeout = RSpec.configuration.send(:wait_timeout)
       RSpec.configuration.wait_timeout = 3
 
       begin

--- a/spec/wait_spec.rb
+++ b/spec/wait_spec.rb
@@ -43,7 +43,7 @@ describe "wait" do
       end
 
       it "respects a timeout specified in configuration" do
-        original_timeout = RSpec.configuration.wait_timeout
+        original_timeout = RSpec.configuration.send(:wait_timeout)
         RSpec.configuration.wait_timeout = 3
 
         begin
@@ -118,7 +118,7 @@ describe "wait" do
       end
 
       it "respects a timeout specified in configuration" do
-        original_timeout = RSpec.configuration.wait_timeout
+        original_timeout = RSpec.configuration.send(:wait_timeout)
         RSpec.configuration.wait_timeout = 3
 
         begin


### PR DESCRIPTION
quite clunky fix, but it does the job. Seems ruby 2.3 considers the wait_timeout and wait_delay methods private...

Also temporarily disabled 1.9.3 builds as to let travis pass for now.