### PR TITLE
Support the raise_error block matcher

### DIFF
--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -86,6 +86,18 @@ describe "wait_for" do
         wait_for(progress).to eq(".")
       }.not_to raise_error
     end
+
+    it "waits for block matchers when expectation is met" do
+      expect {
+        wait_for { raise RuntimeError }.to raise_error(RuntimeError)
+      }.not_to raise_error
+    end
+
+    it "waits for block matchers when expectation is not met" do
+      expect {
+        wait_for { progress }.to raise_error(RuntimeError)
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
   end
 
   context "not_to" do
@@ -175,6 +187,18 @@ describe "wait_for" do
       expect {
         wait_for(progress).not_to eq("..")
       }.not_to raise_error
+    end
+
+    it "waits for block matchers when expectation is met" do
+      expect {
+        wait_for { progress }.not_to raise_error
+      }.not_to raise_error
+    end
+
+    it "waits for block matchers when expectation is not met" do
+      expect {
+        wait_for { raise RuntimeError }.not_to raise_error
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end
 end

--- a/spec/wait_spec.rb
+++ b/spec/wait_spec.rb
@@ -96,6 +96,18 @@ describe "wait" do
           wait.for(progress).to eq(".")
         }.not_to raise_error
       end
+
+      it "waits for block matchers when expectation is met" do
+        expect {
+          wait.for { raise RuntimeError }.to raise_error(RuntimeError)
+        }.not_to raise_error
+      end
+
+      it "waits for block matchers when expectation is not met" do
+        expect {
+          wait.for { progress }.to raise_error(RuntimeError)
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
     end
 
     context "not_to" do
@@ -194,6 +206,18 @@ describe "wait" do
         expect {
           wait.for(progress).not_to eq("..")
         }.not_to raise_error
+      end
+
+      it "waits for block matchers when expectation is met" do
+        expect {
+          wait.for { progress }.not_to raise_error
+        }.not_to raise_error
+      end
+
+      it "waits for block matchers when expectation is not met" do
+        expect {
+          wait.for { raise RuntimeError }.not_to raise_error
+        }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
     end
   end


### PR DESCRIPTION
## ⚠️  🚧 Work in Progress

Related to #20. The first commit adds red tests. Please fork and continue your branch off of this `block-matchers` branch in an attempt to make these red tests green while preserving all existing tests and keeping them green as well. Thank you!