### PR TITLE
remove unncessary loop

### DIFF
--- a/lib/rspec/wait/handler.rb
+++ b/lib/rspec/wait/handler.rb
@@ -7,15 +7,13 @@ module RSpec
         failure = nil
 
         Timeout.timeout(RSpec.configuration.wait_timeout) do
-          loop do
-            begin
-              actual = target.respond_to?(:call) ? target.call : target
-              super(actual, *args, &block)
-              break
-            rescue RSpec::Expectations::ExpectationNotMetError => failure
-              sleep RSpec.configuration.wait_delay
-              retry
-            end
+          begin
+            actual = target.respond_to?(:call) ? target.call : target
+            super(actual, *args, &block)
+            break
+          rescue RSpec::Expectations::ExpectationNotMetError => failure
+            sleep RSpec.configuration.wait_delay
+            retry
           end
         end
       rescue Timeout::Error

--- a/lib/rspec/wait/handler.rb
+++ b/lib/rspec/wait/handler.rb
@@ -10,7 +10,6 @@ module RSpec
           begin
             actual = target.respond_to?(:call) ? target.call : target
             super(actual, *args, &block)
-            break
           rescue RSpec::Expectations::ExpectationNotMetError => failure
             sleep RSpec.configuration.wait_delay
             retry


### PR DESCRIPTION
There is no need to loop over a successful result (hence the break).  The retry provides all the looping behavior needed.