### PR TITLE
Do not use the same matcher instance on each wait iteration

### DIFF
--- a/lib/rspec/wait/handler.rb
+++ b/lib/rspec/wait/handler.rb
@@ -3,13 +3,13 @@ require "timeout"
 module RSpec
   module Wait
     module Handler
-      def handle_matcher(target, *args, &block) # rubocop:disable Metrics/MethodLength
+      def handle_matcher(target, matcher, message=nil, &block) # rubocop:disable Metrics/MethodLength
         failure = nil
 
         Timeout.timeout(RSpec.configuration.wait_timeout) do
           begin
             actual = target.respond_to?(:call) ? target.call : target
-            super(actual, *args, &block)
+            super(actual, matcher.clone, message, &block)
           rescue RSpec::Expectations::ExpectationNotMetError => failure
             sleep RSpec.configuration.wait_delay
             retry

--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -30,16 +30,13 @@ describe "wait_for" do
     end
 
     it "does not use previous matcher state" do
-      feeder = Fiber.new do
-        a = 0
-        loop do
-          Fiber.yield [a, nil]
-          a += 1
-        end
-      end
+      feeder = Enumerator.new([
+        [1, nil],
+        [2, nil],
+      ])
       
       expect {
-        wait_for { feeder.resume }.to contain_exactly(nil, 2)
+        wait.for { feeder.next }.to contain_exactly(nil, 2)
       }.not_to raise_error
     end
 
@@ -124,16 +121,13 @@ describe "wait_for" do
     end
 
     it "does not use previous matcher state" do
-      feeder = Fiber.new do
-        a = 0
-        loop do
-          Fiber.yield a >= 2 ? [a, nil] : [1, nil]
-          a += 1
-        end
-      end
+      feeder = Enumerator.new([
+        [1, nil],
+        [2, nil],
+      ])
       
       expect {
-        wait_for { feeder.resume }.not_to contain_exactly(nil, 1)
+        wait_for { feeder.next }.not_to contain_exactly(nil, 1)
       }.not_to raise_error
     end
 

--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -29,6 +29,20 @@ describe "wait_for" do
       }.not_to raise_error
     end
 
+    it "does not use previous matcher state" do
+      feeder = Fiber.new do
+        a = 0
+        loop do
+          Fiber.yield [a, nil]
+          a += 1
+        end
+      end
+      
+      expect {
+        wait_for { feeder.resume }.to contain_exactly(nil, 2)
+      }.not_to raise_error
+    end
+
     it "fails if the matcher never passes" do
       expect {
         wait_for { progress }.to eq("...")
@@ -106,6 +120,20 @@ describe "wait_for" do
     it "re-evaluates the actual value" do
       expect {
         wait_for { progress.dup }.not_to eq("")
+      }.not_to raise_error
+    end
+
+    it "does not use previous matcher state" do
+      feeder = Fiber.new do
+        a = 0
+        loop do
+          Fiber.yield a >= 2 ? [a, nil] : [1, nil]
+          a += 1
+        end
+      end
+      
+      expect {
+        wait_for { feeder.resume }.not_to contain_exactly(nil, 1)
       }.not_to raise_error
     end
 

--- a/spec/wait_spec.rb
+++ b/spec/wait_spec.rb
@@ -31,16 +31,13 @@ describe "wait" do
       end
 
       it "does not use previous matcher state" do
-        feeder = Fiber.new do
-          a = 0
-          loop do
-            Fiber.yield [a, nil]
-            a += 1
-          end
-        end
+        feeder = Enumerator.new([
+          [1, nil],
+          [2, nil],
+        ])
         
         expect {
-          wait.for { feeder.resume }.to contain_exactly(nil, 2)
+          wait.for { feeder.next }.to contain_exactly(nil, 2)
         }.not_to raise_error
       end
 
@@ -134,16 +131,13 @@ describe "wait" do
       end
 
       it "does not use previous matcher state" do
-        feeder = Fiber.new do
-          a = 0
-          loop do
-            Fiber.yield a >= 2 ? [a, nil] : [1, nil]
-            a += 1
-          end
-        end
+        feeder = Enumerator.new([
+          [1, nil],
+          [2, nil],
+        ])
         
         expect {
-          wait.for { feeder.resume }.not_to contain_exactly(nil, 1)
+          wait.for { feeder.next }.not_to contain_exactly(nil, 1)
         }.not_to raise_error
       end
 

--- a/spec/wait_spec.rb
+++ b/spec/wait_spec.rb
@@ -30,6 +30,20 @@ describe "wait" do
         }.not_to raise_error
       end
 
+      it "does not use previous matcher state" do
+        feeder = Fiber.new do
+          a = 0
+          loop do
+            Fiber.yield [a, nil]
+            a += 1
+          end
+        end
+        
+        expect {
+          wait.for { feeder.resume }.to contain_exactly(nil, 2)
+        }.not_to raise_error
+      end
+
       it "fails if the matcher never passes" do
         expect {
           wait.for { progress }.to eq("...")
@@ -116,6 +130,20 @@ describe "wait" do
       it "re-evaluates the actual value" do
         expect {
           wait.for { progress.dup }.not_to eq("")
+        }.not_to raise_error
+      end
+
+      it "does not use previous matcher state" do
+        feeder = Fiber.new do
+          a = 0
+          loop do
+            Fiber.yield a >= 2 ? [a, nil] : [1, nil]
+            a += 1
+          end
+        end
+        
+        expect {
+          wait.for { feeder.resume }.not_to contain_exactly(nil, 1)
         }.not_to raise_error
       end
 


### PR DESCRIPTION
Fixes: #20

Some notes on the rootcause and solution:

`contain_exactly` is one of those matchers that stores some intermediate computations internally. And hence we reuse this matcher object throughout the whole `handle_matcher` loop, it ignores the actual results and uses it's internal state computed on the first iteration.

The solution proposed is simply to `clone` initial matcher every iteration.

Please note that I have no idea is the solution is optimal, so any opinions welcome.